### PR TITLE
feat: add "Run to stage" option in the repl

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2366,3 +2366,5 @@ h1:target::before, .h1:target::before, h2:target::before, .h2:target::before, h3
 .decaffeinate-repl-console { right: 0; }
 
 .decaffeinate-repl-demo-code { display:none; }
+
+.decaffeinate-repl-stage-option { margin-right: 15px; }

--- a/repl/index.html
+++ b/repl/index.html
@@ -74,6 +74,20 @@ cubes = (math.cube num for num in list)
   <form class="form decaffeinate-repl-toolbar">
     <div class="pull-left">
       <div class="form-group">
+        <span class="decaffeinate-repl-stage-option">
+          Run to stage:
+          <select id="option-stage">
+            <option value="full">Full Decaffeinate</option>
+            <option value="coffeescript-parser">CoffeeScript parser</option>
+            <option value="coffee-lex">coffee-lex</option>
+            <option value="decaffeinate-parser">decaffeinate-parser</option>
+            <option value="NormalizeStage">NormalizeStage</option>
+            <option value="MainStage">MainStage</option>
+            <option value="AddVariableDeclarationsStage">AddVariableDeclarationsStage</option>
+            <option value="SemicolonsStage">SemicolonsStage</option>
+            <option value="EsnextStage">EsnextStage</option>
+          </select>
+        </span>
         <label for="option-evaluate">
           <input id="option-evaluate" type="checkbox"> Evaluate
         </label>

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -112,10 +112,23 @@
     return {
       get: function () {
         return $element.is(":checked");
-      } ,
+      },
       set: function (value) {
         var setting = value !== 'false' && value !== false;
         $element.prop('checked', setting);
+      },
+      enumerable: true,
+      configurable: false
+    };
+  }
+
+  function $select($element){
+    return {
+      get: function () {
+        return $element.val();
+      },
+      set: function (value) {
+        $element.val(value);
       },
       enumerable: true,
       configurable: false
@@ -127,15 +140,18 @@
    */
   function Options () {
     var $evaluate = $('#option-evaluate');
+    var $stage = $('#option-stage');
 
     var options = {};
     Object.defineProperties(options, {
-      'evaluate': $checkbox($evaluate)
+      'evaluate': $checkbox($evaluate),
+      'stage': $select($stage)
     });
 
     // Merge in defaults
     var defaults = {
-      evaluate: true
+      evaluate: true,
+      stage: 'full'
     };
 
     _.assign(options, defaults);
@@ -149,7 +165,7 @@
   function REPL () {
     this.storage = new StorageService();
     var state = this.storage.get('replState') || {};
-    var parsedQuery = UriUtils.parseQuery()
+    var parsedQuery = UriUtils.parseQuery();
     if(parsedQuery && parsedQuery.code || state.code) {
       _.assign(state, UriUtils.parseQuery());
     } else {
@@ -208,8 +224,9 @@
     var code = this.getSource();
     this.clearOutput();
 
+    var runToStage = this.options.stage === 'full' ? null : this.options.stage;
     try {
-      transformed = decaffeinate.convert(code).code;
+      transformed = decaffeinate.convert(code, {runToStage: runToStage}).code;
     } catch (err) {
       if (decaffeinate.PatchError.detect(err)) {
         this.printError(decaffeinate.PatchError.prettyPrint(err));


### PR DESCRIPTION
This is the website side of a change to the repl to allow running decaffeinate
part-way to inspect intermediate results.

One nice advantage of the pretty-printed AST/token format is that you can use
the expand/collapse feature in the right-side editor automatically.

Some future improvements not done here:
* Ideally you'd be able to cross-reference code with AST nodes by clicking
  and/or hovering, like you can do at http://astexplorer.net/ . Since code
  ranges are displayed in a standard format, we could potentially just use
  regexes or something to match that format in the repl.
* Ideally we'd know when the contents in the right editor are JavaScript, and
  gray out the "evaluate" button if not.

Here's a live demo:
http://www.alangpierce.com/decaffeinate-project.org/repl/#?evaluate=false&stage=full&code=x%20%3D%20a%20%22%23%7Bb%20%2B%20c%7D%22