### PR TITLE
fix: use dark text in the "run to stage" select

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2368,3 +2368,4 @@ h1:target::before, .h1:target::before, h2:target::before, .h2:target::before, h3
 .decaffeinate-repl-demo-code { display:none; }
 
 .decaffeinate-repl-stage-option { margin-right: 15px; }
+.decaffeinate-repl-stage-option select { color: #333; }


### PR DESCRIPTION
It looks like a recent Chrome update made it so the text color for `select`
elements gets inherited, so it was showing white on light gray for me. This was
also happening in Firefox (on Mac) but not Safari. To fix, I just specified the
color explicitly in the CSS.

Demo: http://www.alangpierce.com/decaffeinate-project.org/repl/#?evaluate=true&stage=full&code=