### PR TITLE
fix: ignore mz when building the decaffeinate bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .gobble-build
 lib
+.idea

--- a/script/rebuild
+++ b/script/rebuild
@@ -44,7 +44,7 @@ configureGithubRemote decaffeinate/decaffeinate-project.org
 # Build the browser version.
 browserify \
   --require decaffeinate \
-  --external graceful-fs \
+  --ignore mz \
   --standalone decaffeinate \
   --outfile scripts/decaffeinate.js
 


### PR DESCRIPTION
This was causing a crash on initial load due to some code that was assuming we
were running in node.