### PR TITLE
feat: add cs2, useJSModules, and loose options to repl

### DIFF
--- a/repl/index.html
+++ b/repl/index.html
@@ -89,9 +89,26 @@ cubes = (math.cube num for num in list)
             <option value="EsnextStage">EsnextStage</option>
           </select>
         </span>
-        <label for="option-evaluate">
-          <input id="option-evaluate" type="checkbox"> Evaluate
-        </label>
+        <span class="decaffeinate-repl-stage-option">
+          <label for="option-use-cs2">
+            <input id="option-use-cs2" type="checkbox"> --use-cs2
+          </label>
+        </span>
+        <span class="decaffeinate-repl-stage-option">
+          <label for="option-use-js-modules">
+            <input id="option-use-js-modules" type="checkbox"> --use-js-modules
+          </label>
+        </span>
+        <span class="decaffeinate-repl-stage-option">
+          <label for="option-loose">
+            <input id="option-loose" type="checkbox"> --loose
+          </label>
+        </span>
+        <span class="decaffeinate-repl-stage-option">
+          <label for="option-evaluate">
+            <input id="option-evaluate" type="checkbox"> Evaluate
+          </label>
+        </span>
       </div>
     </div>
   </form>

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -139,17 +139,26 @@
    * Decaffeinate options for transpilation as used by the REPL
    */
   function Options () {
+    var $useCS2 = $('#option-use-cs2');
+    var $useJSModules = $('#option-use-js-modules');
+    var $loose = $('#option-loose');
     var $evaluate = $('#option-evaluate');
     var $stage = $('#option-stage');
 
     var options = {};
     Object.defineProperties(options, {
+      'useCS2': $checkbox($useCS2),
+      'useJSModules': $checkbox($useJSModules),
+      'loose': $checkbox($loose),
       'evaluate': $checkbox($evaluate),
       'stage': $select($stage)
     });
 
     // Merge in defaults
     var defaults = {
+      useCS2: false,
+      useJSModules: false,
+      loose: false,
       evaluate: true,
       stage: 'full'
     };
@@ -226,7 +235,12 @@
 
     var runToStage = this.options.stage === 'full' ? null : this.options.stage;
     try {
-      transformed = decaffeinate.convert(code, {runToStage: runToStage}).code;
+      transformed = decaffeinate.convert(code, {
+        runToStage: runToStage,
+        useCS2: this.options.useCS2,
+        useJSModules: this.options.useJSModules,
+        loose: this.options.loose
+      }).code;
     } catch (err) {
       if (decaffeinate.PatchError.detect(err)) {
         this.printError(decaffeinate.PatchError.prettyPrint(err));


### PR DESCRIPTION
This should make it easier to link to bugs in different configurations, try out
CS2 support, and view the tokens and AST for CS1 and CS2.