### PR TITLE
fix: unbreak Firefox/Safari by ignoring @babel/generator in browserify

### DIFF
--- a/script/rebuild
+++ b/script/rebuild
@@ -45,6 +45,7 @@ configureGithubRemote decaffeinate/decaffeinate-project.org
 browserify \
   --require decaffeinate \
   --ignore mz \
+  --ignore @babel/generator \
   --standalone decaffeinate \
   --outfile scripts/decaffeinate.js
 


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/1352

Babel started shipping ES6 code, including a declaration of the form
`class Buffer`. It looks like browserify doesn't support class syntax and
treated it as an access of the `Buffer` global, so it injected `Buffer` for that
module, which broke because you can't declare a class with the same name as a
parameter. It still worked in Chrome because Chrome fails at execution time and
the module was never executed, but it failed in Firefox and Safari because they
fail when parsing the code. Long-term, it may make sense to move off of
browserify, but in the meantime, an easy fix is to tell browserify to ignore
that module, since it's not actually used.